### PR TITLE
Wrong module name in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 ## Install
 
 ```
-$ npm install --save-dev gulp-svg-spritesheet
+$ npm install --save-dev gulp-svg-json-spritesheet
 ```
 
 
@@ -14,7 +14,7 @@ $ npm install --save-dev gulp-svg-spritesheet
 
 ```js
 var gulp = require('gulp');
-var svg = require('gulp-svg-spritesheet');
+var svg = require('gulp-svg-json-spritesheet');
 
 gulp.task('default', function() {
   return gulp.src('svg/*.svg')


### PR DESCRIPTION
The module name in readme.md is gulp-svg-spritesheet instead of gulp-svg-json-spritesheet.