### PR TITLE
Wrong module name again in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function(file, opts) {
 
     if (file.isStream()) {
       callback(new gutil.PluginError(
-          'gulp-svg-spritesheet', 'Streaming not supported'));
+          'gulp-svg-json-spritesheet', 'Streaming not supported'));
       return;
     }
 
@@ -42,7 +42,7 @@ module.exports = function(file, opts) {
         spritesheet[fileName] = result;
       });
     } catch (error) {
-      this.emit('error', new gutil.PluginError('gulp-svg-spritesheet', error));
+      this.emit('error', new gutil.PluginError('gulp-svg-json-spritesheet', error));
     }
 
     callback();


### PR DESCRIPTION
Wrong module name: gulp-svg-spritesheet instead of gulp-svg-json-spritesheet